### PR TITLE
Remove additionnal tabs

### DIFF
--- a/openbsd-games.db
+++ b/openbsd-games.db
@@ -2150,8 +2150,8 @@ Hints	slow graphics performance on Intel UHD 630/Tigerlake
 Genre	puzzle
 Tags	first-person, indie
 Year	2021
-Dev		Brenton Wildes
-Pub		Brenton Wildes
+Dev	Brenton Wildes
+Pub	Brenton Wildes
 Version
 Status	runs (2021-12-21)
 Game	Little Racers STREET


### PR DESCRIPTION
There are two tabs instead of one for those two lines. It gives me warnings when parsing.