### PR TITLE
Set updated field to added field by default

### DIFF
--- a/openbsd-games.db
+++ b/openbsd-games.db
@@ -13,7 +13,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Adventures of Mr. Hat
 Cover
 Engine	godot
@@ -29,7 +29,7 @@ Pub	Fun Quarter
 Version	Early Access
 Status	runs (2022-05-13)
 Added	2022-05-13
-Updated
+Updated	2022-05-13
 Game	The Adventures of Shuggy
 Cover	Adventures_of_Shuggy_The_-_cover.png
 Engine	FNA
@@ -45,7 +45,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Aedemphia
 Cover	aedemphia.png
 Engine	RPG Maker
@@ -61,7 +61,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Aeternum
 Cover
 Engine	FNA
@@ -93,7 +93,7 @@ Pub
 Version
 Status	works with some setup steps required
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Akane the Kunoichi
 Cover	Akane_the_Kunoichi_cover.jpg
 Engine	XNA
@@ -109,7 +109,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Alien Shepherd
 Cover
 Engine	HashLink
@@ -125,7 +125,7 @@ Pub	Florent Espanet
 Version	1.0.1
 Status	runs with bugs - graphics artefacts (2022-06-11)
 Added	2022-06-11
-Updated
+Updated	2022-06-11
 Game	Always Sometimes Monsters
 Cover	Always_Sometimes_Monsters.jpg
 Engine	NW.js
@@ -141,7 +141,7 @@ Pub
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Amazing Princess Sarah
 Cover	Amazing_Princess_Sarah_cover.jpg
 Engine	XNA
@@ -157,7 +157,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Amnesia: The Dark Descent
 Cover
 Engine	amnesia-tdd
@@ -173,7 +173,7 @@ Pub	Frictional Games
 Version
 Status	runs (2021-10-26)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Apotheon
 Cover	Apotheon_-_cover.jpg
 Engine	FNA
@@ -189,7 +189,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Apple Jack 1&2
 Cover	Apple_Jack_cover.jpg
 Engine	XNA
@@ -205,7 +205,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Aquaria
 Cover	Aquaria_-_cover.jpg
 Engine
@@ -221,7 +221,7 @@ Pub
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Arx Fatalis
 Cover	Arx_Fatalis_Cover.jpg
 Engine
@@ -237,7 +237,7 @@ Pub	JoWood Productions
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Atom Zombie Smasher
 Cover	AZS.jpg
 Engine
@@ -253,7 +253,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Average Everyday Adventures of Samantha Browne
 Cover	The_Average_Everyday_Adventures_of_Samantha_Browne_cover.jpg
 Engine	ren'py
@@ -269,7 +269,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Axiom Verge
 Cover	Axiom_Verge_-_cover.jpg
 Engine	FNA
@@ -301,7 +301,7 @@ Pub	Black Isle Studios
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Baldur's Gate 2
 Cover	Baldurs_Gate_II_Shadows_of_Amn_cover.jpg
 Engine	Infinity Engine
@@ -317,7 +317,7 @@ Pub	Black Isle Studios
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Banana Hell
 Cover
 Engine	godot
@@ -333,7 +333,7 @@ Pub	Petriheart
 Version
 Status	runs (2021-11-25)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Barony
 Cover	Barony_cover.jpg
 Engine
@@ -349,7 +349,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Beholder's Lair
 Cover
 Engine	godot
@@ -365,7 +365,7 @@ Pub	Alpar Entertainment
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Beneath a Steel Sky
 Cover	Beneath_a_Steel_Sky_Box.png
 Engine	ScummVM
@@ -381,7 +381,7 @@ Pub	Virgin Interactive
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Bird Assassin
 Cover	Bird_Assassin_cover.png
 Engine	XNA
@@ -397,7 +397,7 @@ Pub
 Version
 Status	works (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Blackwell Epiphany
 Cover	The_Blackwell_Epiphany_cover.png
 Engine	AGS
@@ -413,7 +413,7 @@ Pub
 Version
 Status	needs manual setup
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Blastronaut
 Cover
 Engine	godot
@@ -429,7 +429,7 @@ Pub	Perfoon
 Version	demo (downloaded 2022-04-02)
 Status	runs (2022-04-02)
 Added	2022-04-03
-Updated
+Updated	2022-04-03
 Game	Bleed
 Cover	Bleed_boxart.JPG
 Engine	FNA
@@ -445,7 +445,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Bleed 2
 Cover	Bleed_2_cover.jpg
 Engine	FNA
@@ -477,7 +477,7 @@ Pub	Playtonic Friends
 Version
 Status	runs (2022-08-18)
 Added	2022-08-19
-Updated
+Updated	2022-08-19
 Game	Bottomless
 Cover
 Engine	godot
@@ -493,7 +493,7 @@ Pub
 Version
 Status	runs (2021-10-31)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Breath of Death VII
 Cover	Breath_of_death_vii.jpg
 Engine	XNA
@@ -509,7 +509,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Broken Sword II: The Smoking Mirror
 Cover	Broken_Sword_II_The_Smoking_Mirror_Coverart.png
 Engine	Virtual Theatre
@@ -525,7 +525,7 @@ Pub	Virgin Interactive
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Broken Sword: The Shadow of the Templars
 Cover	Broken_Sword_Shadow_of_the_Templars_Coverart.png
 Engine	Virtual Theatre
@@ -541,7 +541,7 @@ Pub	Virgin Interactive
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Brotato
 Cover
 Engine	godot
@@ -557,7 +557,7 @@ Pub	Blobfish
 Version	demo (2022-06-07)
 Status	runs (2022-06-07)
 Added	2022-06-07
-Updated
+Updated	2022-06-07
 Game	Brushwood Buddies
 Cover	Brushwood_Buddies_cover.jpg
 Engine	FNA
@@ -573,7 +573,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Burning Knight
 Cover	Burning_Knight_cover.jpg
 Engine	MonoGame
@@ -589,7 +589,7 @@ Pub
 Version
 Status	runs with major bugs
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Caesar 3
 Cover	Caesar_III_Cover.png
 Engine
@@ -605,7 +605,7 @@ Pub	Sierra Entertainment
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Cannon Fodder
 Cover	Cannon_Fodder_Coverart.jpg
 Engine
@@ -621,7 +621,7 @@ Pub	Eidos Interactive
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Cannon Fodder 2
 Cover	Cannon_Fodder_2_-_cover.png
 Engine
@@ -637,7 +637,7 @@ Pub	Codemasters
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Capsized
 Cover	Capsized_-_cover.png
 Engine	FNA
@@ -653,7 +653,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Capsule Force
 Cover
 Engine	FNA
@@ -669,7 +669,7 @@ Pub	Iron Galaxy
 Version
 Status	runs (2021-08-19)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Capsule Wars
 Cover
 Engine	godot
@@ -685,7 +685,7 @@ Pub
 Version
 Status	runs (2021-10-31)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Case of the Golden Idol
 Cover
 Engine	godot
@@ -701,7 +701,7 @@ Pub	Playstack
 Version	1.3.2
 Status	runs (2022-11-16)
 Added	2022-11-17
-Updated
+Updated	2022-11-17
 Game	Cat Box Paradox
 Cover
 Engine	godot
@@ -717,7 +717,7 @@ Pub	BiscuitLocker
 Version
 Status	runs (2021-12-10)
 Added	2021-12-10
-Updated
+Updated	2021-12-10
 Game	Cat Cafe Manager
 Cover
 Engine	godot
@@ -733,7 +733,7 @@ Pub	Freedom Games
 Version	1.0.388
 Status	runs (2022-04-15)
 Added	2022-04-15
-Updated
+Updated	2022-04-15
 Game	The Cat Lady
 Cover	The_Cat_Lady_-_cover.jpg
 Engine	AGS
@@ -749,7 +749,7 @@ Pub	Screen 7
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Cave - Legend of the Forge
 Cover
 Engine	godot
@@ -765,7 +765,7 @@ Pub	bitbrain
 Version
 Status	runs (2021-10-31)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Celeste
 Cover	345px-Celeste_cover.png
 Engine	FNA
@@ -781,7 +781,7 @@ Pub
 Version
 Status	major limitations - no audio
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Chaos Heart
 Cover	Chaos_Heart_cover.png
 Engine
@@ -797,7 +797,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Charlie Murder
 Cover	Charlie_Murder_cover.jpg
 Engine	FNA
@@ -813,7 +813,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Chasm
 Cover	Chasm_cover.jpg
 Engine	FNA
@@ -829,7 +829,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Chess Survivors
 Cover
 Engine	Godot
@@ -845,7 +845,7 @@ Pub	Aarimous
 Version	Early Access 0.6.2.1
 Status	runs (2022-11-13)
 Added	2022-11-17
-Updated
+Updated	2022-11-17
 Game	CometStriker
 Cover	CometStriker_cover.jpg
 Engine	FNA
@@ -861,7 +861,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Command & Conquer
 Cover	Command__Conquer_cover.jpg
 Engine
@@ -877,7 +877,7 @@ Pub	Virgin Interactive
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Command & Conquer: Red Alert
 Cover	Command__Conquer_Red_Alert_cover.jpg
 Engine
@@ -893,7 +893,7 @@ Pub	Virgin Interactive
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Crawlers and Brawlers
 Cover
 Engine	FNA
@@ -909,7 +909,7 @@ Pub	Ugly Beard Games, LLC
 Version
 Status	runs offline mode only (2021-08-19)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	CrossCode
 Cover	CrossCode_cover.jpg
 Engine	NW.js
@@ -925,7 +925,7 @@ Pub	Deck13
 Version
 Status	manual setup needed; some non-gamebreaking bugs
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Cruelty Squad
 Cover
 Engine	godot
@@ -941,7 +941,7 @@ Pub	Consumer Softproducts
 Version
 Status	runs (2021-09-06)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Cryptark
 Cover	CRYPTARK_Cover.jpg
 Engine	FNA
@@ -957,7 +957,7 @@ Pub
 Version
 Status	works (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Crystal Project
 Cover
 Engine	FNA
@@ -973,7 +973,7 @@ Pub	Andrew Willman
 Version	1.0.11
 Status	runs (2022-04-16)
 Added	2022-04-16
-Updated
+Updated	2022-04-16
 Game	Cthulhu Saves the World
 Cover	CthulhuSavestheWorld.png
 Engine	XNA
@@ -989,7 +989,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Curse of the Crescent Isle DX
 Cover	Curse_of_the_Crescent_Isle_DX_cover.jpg
 Engine	FNA
@@ -1005,7 +1005,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Cursed Gem
 Cover
 Engine	godot
@@ -1021,7 +1021,7 @@ Pub	Vega Games
 Version	1.0.5
 Status	runs (2021-10-31)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Cute Cats
 Cover
 Engine	godot
@@ -1037,7 +1037,7 @@ Pub	KnKo
 Version
 Status	runs (2021-11-10)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Cyber-doge 2077: Meme runner
 Cover
 Engine	godot
@@ -1053,7 +1053,7 @@ Pub	Take Toad
 Version
 Status	runs (2021-11-10)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dad Quest
 Cover	Dad_Quest_cover.jpg
 Engine	MonoGame
@@ -1069,7 +1069,7 @@ Pub	Excalibur Publishing
 Version
 Status	minor limitations - no gamepad support
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dark Crypt
 Cover
 Engine	godot
@@ -1085,7 +1085,7 @@ Pub	Daisy Games
 Version
 Status	runs (2021-10-15)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dark Sheep
 Cover
 Engine	godot
@@ -1101,7 +1101,7 @@ Pub	Daisy Games
 Version
 Status	runs (2021-12-10)
 Added	2021-12-10
-Updated
+Updated	2021-12-10
 Game	Dead Cells
 Cover	Dead_Cells_cover.jpg
 Engine	hashlink
@@ -1117,7 +1117,7 @@ Pub
 Version
 Status	works (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dead Pixels
 Cover	Dead_Pixels_cover.jpg
 Engine	XNA
@@ -1133,7 +1133,7 @@ Pub
 Version
 Status	currently not working
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dead Pixels II
 Cover	Dead_Pixels_II_cover.jpg
 Engine	FNA
@@ -1149,7 +1149,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Delta-V: Rings of Saturn
 Cover
 Engine	godot
@@ -1165,7 +1165,7 @@ Pub	Kodera Software, Kurki.games
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Democracy 3
 Cover	Democracy_3_-_cover.png
 Engine	Irrlicht Engine
@@ -1181,7 +1181,7 @@ Pub
 Version
 Status	browser needed to run
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Descent
 Cover	Descent_cover.jpg
 Engine	Descent Engine
@@ -1197,7 +1197,7 @@ Pub	Interplay Entertainment
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Descent II
 Cover	Descent_II_-_cover.jpg
 Engine	Descent Engine
@@ -1213,7 +1213,7 @@ Pub	Interplay Entertainment
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Diablo
 Cover	Diablo_cover.jpg
 Engine
@@ -1229,7 +1229,7 @@ Pub	Blizzard Entertainment
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dice Tribes: Ambitions
 Cover
 Engine	HashLink
@@ -1261,7 +1261,7 @@ Pub	Gagonfe
 Version
 Status	runs (2021-12-22)
 Added	2021-12-22
-Updated
+Updated	2021-12-22
 Game	Diehard Dungeon
 Cover	Diehard_Dungeon_cover.jpg
 Engine	XNA
@@ -1277,7 +1277,7 @@ Pub
 Version
 Status	works with modifications - libCSteamworks stub (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Dig
 Cover	The_Dig_Cover.jpg
 Engine	SCUMM
@@ -1293,7 +1293,7 @@ Pub
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dino Eggs: Rebirth
 Cover
 Engine	FNA
@@ -1309,7 +1309,7 @@ Pub	Davie H Schroeder
 Version
 Status	runs (2021-08-19)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Dishwasher: Vampire Smile
 Cover	The_Dishwasher_Vampire_Smile_cover.jpg
 Engine	FNA
@@ -1325,7 +1325,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Doki Doki Literature Club!
 Cover	DDLC_cover.jpg
 Engine	Ren'Py 6
@@ -1341,7 +1341,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dome Keeper (formerly Dome Romantik)
 Cover
 Engine	godot
@@ -1389,7 +1389,7 @@ Pub	Heartbit Interactive
 Version
 Status	runs with bugs, e.g. crash on window resizing (2021-08-23)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Doppelganger
 Cover
 Engine
@@ -1405,7 +1405,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Downfall
 Cover	Downfall_cover.jpg
 Engine	AGS
@@ -1421,7 +1421,7 @@ Pub
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Draw A Stickman: EPIC
 Cover	Draw_a_Stickman_EPIC_logo.png
 Engine	XNA/MonoGame
@@ -1437,7 +1437,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dune 2000
 Cover	Dune_2000_cover.jpg
 Engine
@@ -1453,7 +1453,7 @@ Pub	Virgin Interactive
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dust: An Elysian Tail
 Cover	Dust_An_Elysian_Tail_-_cover.png
 Engine	FNA
@@ -1469,7 +1469,7 @@ Pub	Microsoft Studios
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Dustforce DX
 Cover	Dustforce_cover.jpg
 Engine
@@ -1485,7 +1485,7 @@ Pub
 Version
 Status	needs browser
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	DwarfCorp
 Cover
 Engine	FNA
@@ -1501,7 +1501,7 @@ Pub	Completely Fair Games LLC
 Version
 Status	runs (2022-08-27)
 Added	2022-08-28
-Updated
+Updated	2022-08-28
 Game	EXAPUNKS
 Cover	EXAPUNKS_cover.jpg
 Engine
@@ -1517,7 +1517,7 @@ Pub
 Version
 Status	works (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Eagle Island
 Cover	Eagle_Island_cover.jpg
 Engine	MonoGame
@@ -1533,7 +1533,7 @@ Pub	Screenwave Media
 Version
 Status	works with minor bugs - no gamepad support (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Elder Scrolls III: Morrowind
 Cover	The_Elder_Scrolls_III_Morrowind_cover.jpg
 Engine	NetImmerse
@@ -1549,7 +1549,7 @@ Pub	Bethesda Softworks
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Eliza
 Cover	Eliza_-_cover.jpg
 Engine
@@ -1565,7 +1565,7 @@ Pub
 Version
 Status	works (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Elliot Quest
 Cover	Elliot_Quest_cover.jpg
 Engine	NW.js
@@ -1581,7 +1581,7 @@ Pub
 Version
 Status	minor limitations - no gamepad support; needs browser
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Escape Goat
 Cover	Escape_Goat_-_cover.jpg
 Engine	FNA
@@ -1597,7 +1597,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Escape Goat 2
 Cover	Escape_Goat_2_-_cover.png
 Engine	FNA
@@ -1613,7 +1613,7 @@ Pub	Double Fine Productions
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Escape from Monkey Island
 Cover	Escape_from_Monkey_Island_artwork.jpg
 Engine	GrimE
@@ -1629,7 +1629,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Evoland Legendary Edition
 Cover	Evoland-LE_cover.jpg
 Engine	hashlink
@@ -1645,7 +1645,7 @@ Pub
 Version
 Status	not working - needs modifications to steam hashlink library
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Excavation of Hob's Barrow
 Cover
 Engine	AGS
@@ -1661,7 +1661,7 @@ Pub	Wadjet Eye Games
 Version	1.0
 Status	runs with issues displaying text (2022-09-28)
 Added	2022-09-28
-Updated
+Updated	2022-09-28
 Game	Explosionade
 Cover	Explosionade_cover.jpg
 Engine	XNA
@@ -1677,7 +1677,7 @@ Pub
 Version
 Status	currently not working
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Expression Amrilato
 Cover	The_Expression_Amrilato_cover.jpg
 Engine	Ren'Py
@@ -1693,7 +1693,7 @@ Pub	MangaGamer
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Fenimore Fillmore: 3 Skulls of the Toltecs
 Cover
 Engine
@@ -1709,7 +1709,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	FEZ
 Cover	450px-Fez_-_cover.png
 Engine	FNA
@@ -1725,7 +1725,7 @@ Pub	Trapdoor
 Version
 Status	custom version needed - need to use beta version to run
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Fracture Hell
 Cover
 Engine	godot
@@ -1741,7 +1741,7 @@ Pub	Solo Byte Games
 Version
 Status	runs (2021-10-15)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	FRANZ FURY
 Cover
 Engine	godot
@@ -1757,7 +1757,7 @@ Pub	Raffaele Picca
 Version	Demo
 Status	runs (2022-04-13)
 Added	2022-04-14
-Updated
+Updated	2022-04-14
 Game	FTL
 Cover	FTL_-_Faster_Than_Light_-_cover.jpg
 Engine
@@ -1773,7 +1773,7 @@ Pub
 Version
 Status	browser needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Fatal Twelve
 Cover	Fatal_Twelve_cover.jpg
 Engine	Ren'Py
@@ -1789,7 +1789,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Fist Puncher
 Cover	Fist_Puncher_-_cover.png
 Engine	FNA
@@ -1805,7 +1805,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Flinthook
 Cover	Flinthook_cover.jpg
 Engine	FNA
@@ -1821,7 +1821,7 @@ Pub
 Version
 Status	works (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Flotilla
 Cover	Flotilla.jpg
 Engine	FNA
@@ -1837,7 +1837,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Forest's Secret: Mystery of the Frost
 Cover	forests_secret_cover.png
 Engine	libgdx
@@ -1853,7 +1853,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Freespace 2
 Cover	FreeSpace_2.jpg
 Engine
@@ -1869,7 +1869,7 @@ Pub	Interplay Entertainment
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Gabriel Knight: Sins of the Fathers
 Cover	Gabriel_Knight_Sins_of_the_Fathers_Cover.png
 Engine	SCI2
@@ -1885,7 +1885,7 @@ Pub
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Game Type
 Cover	Game_Type_cover.jpg
 Engine	XNA
@@ -1901,7 +1901,7 @@ Pub
 Version
 Status	currently not working
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Gateways
 Cover	Gateways_-_cover.png
 Engine	FNA
@@ -1917,7 +1917,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Gemini Rue
 Cover
 Engine	AGS
@@ -1933,7 +1933,7 @@ Pub	Wadjet Eye Games
 Version
 Status	runs (2021-10-13)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Glitchangels
 Cover	Glitchangels_cover.jpg
 Engine	FNA
@@ -1949,7 +1949,7 @@ Pub	Puppygames
 Version	1.2.2
 Status	works with minor bugs - FAudio crash on exit (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	A Golden Wake
 Cover
 Engine	AGS
@@ -1965,7 +1965,7 @@ Pub	Grundislav Games
 Version
 Status	runs (2021-10-13)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Goop Loop
 Cover
 Engine	godot
@@ -1981,7 +1981,7 @@ Pub	Lone Wulf Studio LLC
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Grand Class Melee 2
 Cover	Grand_Class_Melee_2_cover.jpg
 Engine	XNA
@@ -1997,7 +1997,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Gravity Ace
 Cover
 Engine	godot
@@ -2013,7 +2013,7 @@ Pub	John Watson
 Version
 Status	runs (2021-09-19)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Great Adventurer
 Cover
 Engine
@@ -2029,7 +2029,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Great Plague Exodus
 Cover
 Engine	godot
@@ -2045,7 +2045,7 @@ Pub	Priory Games
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Grimm's Hollow
 Cover	Grimms_Hollow_cover.jpg
 Engine
@@ -2061,7 +2061,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Groov
 Cover
 Engine	FNA
@@ -2077,7 +2077,7 @@ Pub	Metronomaton
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Growing Pains
 Cover	Growing_Pains_cover.jpg
 Engine	FNA
@@ -2093,7 +2093,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Hack Grid
 Cover
 Engine	godot
@@ -2109,7 +2109,7 @@ Pub	Daisy Games
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	HackNet
 Cover	Hacknet_Logo.jpg
 Engine	FNA
@@ -2125,7 +2125,7 @@ Pub	Surprise Attack Games
 Version
 Status	minor limitations - integrated browser module not working
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Haiki
 Cover
 Engine	godot
@@ -2157,7 +2157,7 @@ Pub
 Version	1.2.0
 Status	runs (2021-11-26)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Hashi: Light
 Cover
 Engine	godot
@@ -2173,7 +2173,7 @@ Pub	amiksemo
 Version
 Status	runs (2021-10-15)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	HeXen: Beyond Heretic
 Cover	Hexen_Beyond_Heretic_cover.jpg
 Engine	id Tech 1
@@ -2189,7 +2189,7 @@ Pub	id Software
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	HeXen II
 Cover	Hexen_II_cover.jpg
 Engine	Quake engine
@@ -2205,7 +2205,7 @@ Pub	id Software
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Hedon
 Cover	Hedon_cover.png
 Engine
@@ -2221,7 +2221,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Heretic: Shadow of the Serpent Riders
 Cover	Heretic_cover.jpg
 Engine	id Tech 1
@@ -2237,7 +2237,7 @@ Pub	id Software
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Heroes of Might and Magic 2
 Cover	Heroes_of_Might_and_Magic_II_cover.jpg
 Engine
@@ -2253,7 +2253,7 @@ Pub	3DO
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Heroine's Quest: The Herald of Ragnarok
 Cover	Heroines_Quest.png
 Engine	AGS
@@ -2269,7 +2269,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Highway Blossoms
 Cover	Highway_Blossoms_Remastered.jpg
 Engine	Ren'Py 6
@@ -2285,7 +2285,7 @@ Pub	Sekai Project
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Hive
 Cover	Hive_cover.jpg
 Engine	FNA
@@ -2301,7 +2301,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Hiveswap Friendsim
 Cover	Hiveswap_Friendsim_cover.jpg
 Engine	ren'py
@@ -2317,7 +2317,7 @@ Pub	Fellow Traveller
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Human Diaspora
 Cover
 Engine	godot
@@ -2333,7 +2333,7 @@ Pub	Leocesar3D Productions
 Version	Early Access
 Status	runs (2021-10-28)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Hyphen
 Cover	Hyphen_cover.jpg
 Engine	FNA
@@ -2349,7 +2349,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	I Have No Mouth And I Must Scream
 Cover	I_Have_No_Mouth_and_I_Must_Scream_Cover.jpg
 Engine	SAGA
@@ -2365,7 +2365,7 @@ Pub	Cyberdreams
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	I MAED A GAM3 W1TH Z0MB1ES 1N IT!!!1
 Cover
 Engine	FNA
@@ -2381,7 +2381,7 @@ Pub	Ska Studios
 Version
 Status	runs (2021-11-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Ib
 Cover	IbBanner.png
 Engine
@@ -2397,7 +2397,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Icewind Dale
 Cover	Icewind_Dale_Box.jpg
 Engine	Infinity Engine
@@ -2413,7 +2413,7 @@ Pub	Interplay Entertainment
 Version
 Status	untested; manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Indiana Jones and the Fate of Atlantis
 Cover	Indiana_Jones_and_the_Fate_of_Atlantis_cover.jpg
 Engine	SCUMM
@@ -2429,7 +2429,7 @@ Pub	LucasArts
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Indirection
 Cover
 Engine	godot
@@ -2445,7 +2445,7 @@ Pub	jakes1403
 Version
 Status	runs (2022-01-09)
 Added	2022-01-09
-Updated
+Updated	2022-01-09
 Game	In the House of Silence
 Cover
 Engine	godot
@@ -2461,7 +2461,7 @@ Pub	Kai Ruma Games
 Version
 Status	runs (2021-11-10)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Ion Fury
 Cover	Ion_Fury_logo.jpg
 Engine	Build Engine
@@ -2477,7 +2477,7 @@ Pub	3D Realms
 Version
 Status	needs manual setup - compile eduke32 port (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Jagged Alliance 2
 Cover	Jagged_Alliance_2_-_cover.jpg
 Engine
@@ -2493,7 +2493,7 @@ Pub	TalonSoft
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Jam and the Mystery of the Mysteriously Spooky Mansion
 Cover	jam.png
 Engine	Ren'Py
@@ -2509,7 +2509,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Jazz Jackrabbit
 Cover	Jazz_Jackrabbit_cover.jpg
 Engine
@@ -2525,7 +2525,7 @@ Pub
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Jon Shafer's At the Gates
 Cover	At_the_Gates_cover.jpg
 Engine	FNA
@@ -2541,7 +2541,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Joyspring
 Cover
 Engine	godot
@@ -2557,7 +2557,7 @@ Pub	Studio Heart Engine
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Kathy Rain
 Cover
 Engine	AGS
@@ -2573,7 +2573,7 @@ Pub	Raw Fury
 Version
 Status	runs (2021-10-13)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Kitsune Zero
 Cover
 Engine	FNA
@@ -2589,7 +2589,7 @@ Pub	Kitsune Games
 Version	1.2.0
 Status	runs (2022-09-13)
 Added	2022-09-13
-Updated
+Updated	2022-09-13
 Game	Kitty Tactics
 Cover
 Engine	godot
@@ -2605,7 +2605,7 @@ Pub	Ibe Denaux
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Kotel Ne Gori: A Friend of Lena Boots
 Cover
 Engine	godot
@@ -2621,7 +2621,7 @@ Pub	derevotyan
 Version
 Status	runs (2021-12-22)
 Added	2021-12-22
-Updated
+Updated	2021-12-22
 Game	Lamplight City
 Cover
 Engine	AGS
@@ -2637,7 +2637,7 @@ Pub	Application Systems Heidelberg
 Version
 Status	runs (2021-10-28)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Lands of Lore - The Throne of Chaos
 Cover	Lands_of_Lore_The_Throne_of_Chaos_Coverart.PNG
 Engine	Kyra
@@ -2653,7 +2653,7 @@ Pub	Virgin Interactive
 Version
 Status	needs manual setup - 7zip extract GAME.DAT
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	LaserCat
 Cover	LaserCat_cover.jpg
 Engine	XNA
@@ -2669,7 +2669,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Learn Japanese To Survive! Hiragana Battle
 Cover	Learn_Japanese_Cover.jpg
 Engine
@@ -2685,7 +2685,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Lila's Sky Aark
 Cover
 Engine	godot
@@ -2701,7 +2701,7 @@ Pub	Graffiti Games
 Version
 Status	runs (2022-04-21)
 Added	2022-04-22
-Updated
+Updated	2022-04-22
 Game	Lingo
 Cover
 Engine	godot
@@ -2733,7 +2733,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Lode Runner Online: The Mad Monks' Revenge
 Cover
 Engine	FNA
@@ -2749,7 +2749,7 @@ Pub
 Version	22.09
 Status	runs (2022-10-30)
 Added	2022-10-30
-Updated
+Updated	2022-10-30
 Game	Long Live the Queen
 Cover	Long_Live_the_Queen.jpg
 Engine	Ren'Py 6
@@ -2765,7 +2765,7 @@ Pub	Zone of Games
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Longest Journey
 Cover	The_Longest_Journey_Box.jpg
 Engine	Stark
@@ -2781,7 +2781,7 @@ Pub
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Loom
 Cover	Loom_Cover.jpg
 Engine	SCUMM
@@ -2797,7 +2797,7 @@ Pub	LucasArts
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Lost Cities
 Cover
 Engine	FNA
@@ -2813,7 +2813,7 @@ Pub	BlueLine Games
 Version
 Status	runs (2021-08-19)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Luck be a Landlord
 Cover
 Engine	godot
@@ -2829,7 +2829,7 @@ Pub	TrampolineTales
 Version
 Status	runs (2021-10-15)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Malice & Greed
 Cover
 Engine	godot
@@ -2845,7 +2845,7 @@ Pub	Xendra
 Version
 Status	runs (2021-10-31)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Master of Orion
 Cover	Master_of_Orion_-_cover.jpg
 Engine
@@ -2861,7 +2861,7 @@ Pub	MicroProse
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Mega Man Legacy Collection
 Cover	Mega_Man_Legacy_Collection.jpg
 Engine
@@ -2877,7 +2877,7 @@ Pub	Capcom
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Mercenary Kings
 Cover	Mercenary_kings_boxart.jpg
 Engine	FNA
@@ -2893,7 +2893,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Mewnbase
 Cover
 Engine	libgdx
@@ -2909,7 +2909,7 @@ Pub	Cairn4
 Version
 Status	major manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Miasma: Citizens of Free Thought
 Cover
 Engine	FNA
@@ -2925,7 +2925,7 @@ Pub	David Addis
 Version
 Status	runs (2021-11-03)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Miasma 2: Freedom Uprising
 Cover
 Engine	FNA
@@ -2941,7 +2941,7 @@ Pub	David Addis
 Version
 Status	buggy: missing graphics elements (2021-12-11)
 Added	2021-12-13
-Updated
+Updated	2021-12-13
 Game	Micro Mages
 Cover	Micro_Mages_cover.jpg
 Engine
@@ -2957,7 +2957,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	MidBoss
 Cover	MidBoss_cover.jpg
 Engine	FNA
@@ -2973,7 +2973,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Minecraft
 Cover	Minecraft_cover.jpg
 Engine
@@ -2989,7 +2989,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Mobius Front 83
 Cover
 Engine
@@ -3005,7 +3005,7 @@ Pub	Zachtronics
 Version	03/01/2021
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Molek-Syntez
 Cover	MOLEK-SYNTEZ_cover.jpg
 Engine
@@ -3021,7 +3021,7 @@ Pub
 Version
 Status	works (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Moonshot - The Great Espionage
 Cover
 Engine	godot
@@ -3037,7 +3037,7 @@ Pub	NimbleBeasts
 Version
 Status	works (2021-08-06)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Mount Your Friends
 Cover	Mount_Your_Friends.jpg
 Engine	XNA
@@ -3053,7 +3053,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Mud River
 Cover
 Engine	godot
@@ -3069,7 +3069,7 @@ Pub	RocpainGames
 Version
 Status	runs (2021-10-15)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Murder Miners
 Cover
 Engine	FNA
@@ -3085,7 +3085,7 @@ Pub	JForce Games
 Version
 Status	runs (2021-08-23)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Myst
 Cover	MystCover.png
 Engine	Mohawk Engine
@@ -3101,7 +3101,7 @@ Pub	Broderbund
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Myst III: Exile
 Cover	MYSTIIICOVER.jpg
 Engine	Sprint Engine
@@ -3117,7 +3117,7 @@ Pub	Ubisoft
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Neofeud
 Cover
 Engine	AGS
@@ -3133,7 +3133,7 @@ Pub	Silver Spook Games
 Version
 Status	runs (2021-10-27)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	NeuroVoider
 Cover	NeuroVoider_cover.jpg
 Engine	MonoGame
@@ -3149,7 +3149,7 @@ Pub	Plug In Digital
 Version
 Status	minor limitations - no gamepad support
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Nightfall Hacker
 Cover
 Engine	godot
@@ -3165,7 +3165,7 @@ Pub	Teradile
 Version
 Status	runs (2021-09-06)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Northgard
 Cover	Northgard_cover.jpg
 Engine	hashlink
@@ -3181,7 +3181,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Nuclear Blaze
 Cover
 Engine	hashlink
@@ -3197,7 +3197,7 @@ Pub	Deepnight Games
 Version
 Status	runs (2021-11-24)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	One Finger Death Punch
 Cover	OneFingerDeathPunchcover.jpg
 Engine	XNA
@@ -3213,7 +3213,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Open Sorcery
 Cover	Open_Sorcery_cover.jpg
 Engine
@@ -3229,7 +3229,7 @@ Pub	Open Sorcery Games
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Opus Magnum
 Cover	Opus_Magnum_cover.jpg
 Engine
@@ -3245,7 +3245,7 @@ Pub
 Version
 Status	works (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Osmos
 Cover	Osmos_Coverart.png
 Engine
@@ -3261,7 +3261,7 @@ Pub
 Version
 Status	browser needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Overdriven Reloaded
 Cover	Overdriven_Reloaded_cover.jpg
 Engine	FNA
@@ -3277,7 +3277,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Owlboy
 Cover	Owlboy_-_Cover.png
 Engine	FNA
@@ -3309,7 +3309,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Paralyzed
 Cover
 Engine	godot
@@ -3325,7 +3325,7 @@ Pub	Alexander Lahti
 Version
 Status	runs (2021-11-10)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Penny Arcade's On the Rain-Slick Precipice of Darkness 3
 Cover	Precipice_of_darkness_3.jpg
 Engine	FNA
@@ -3341,7 +3341,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Penny Arcade's On the Rain-Slick Precipice of Darkness 4
 Cover	On_the_Rain-Slick_Precipice_of_Darkness_4_-_cover.jpg
 Engine	XNA
@@ -3357,7 +3357,7 @@ Pub	Penny Arcade, Inc.
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Phoenix Force
 Cover	Phoenix_Force_cover.jpg
 Engine	XNA
@@ -3373,7 +3373,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Planescape: Torment
 Cover	Planescape_Torment_Box.jpg
 Engine	Infinity Engine
@@ -3389,7 +3389,7 @@ Pub	Interplay Entertainment
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	PlanetFriend
 Cover	PlanetFriend_cover.png
 Engine	FNA
@@ -3405,7 +3405,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Postal
 Cover	Postal_Cover.jpg
 Engine	RSPiX
@@ -3421,7 +3421,7 @@ Pub	Ripcord Games
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Press X to Not Die
 Cover	Press_X_to_Not_Die_cover.jpg
 Engine	FNA
@@ -3437,7 +3437,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Primal Light
 Cover	Primal_Light_cover.jpg
 Engine	Godot
@@ -3453,7 +3453,7 @@ Pub	Fat Gem
 Version
 Status	works on brief testing (2021-01-26)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Primordia
 Cover	Primordia_cover.jpg
 Engine	AGS
@@ -3469,7 +3469,7 @@ Pub	Wadjet Eye Games
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Project Heartbeat
 Cover
 Engine	godot
@@ -3485,7 +3485,7 @@ Pub	EIRTeam
 Version
 Status	runs (2021-11-10)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Quake
 Cover	Quake_Cover.jpg
 Engine	Quake Engine
@@ -3501,7 +3501,7 @@ Pub	GT Interactive
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Quake II
 Cover	Quake_II_cover.jpg
 Engine	id Tech 2
@@ -3517,7 +3517,7 @@ Pub	Activision
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Quake III Arena
 Cover	Quake_III_Arena_cover.jpg
 Engine	id Tech 3
@@ -3533,7 +3533,7 @@ Pub	Activision
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Quest for Infamy
 Cover	473px-Quest_for_Infamy_-_Cover.jpg
 Engine
@@ -3549,7 +3549,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Quest of Graal
 Cover
 Engine	godot
@@ -3565,7 +3565,7 @@ Pub	Pixel-Archipel
 Version
 Status	runs (2022-04-13)
 Added	2022-04-14
-Updated
+Updated	2022-04-14
 Game	Retro City Rampage DX
 Cover	Retro_City_Rampage_cover.jpg
 Engine
@@ -3581,7 +3581,7 @@ Pub
 Version
 Status	needs manual setup
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Return to Castle Wolfenstein
 Cover	Return_to_Castle_Wolfenstein_Cover.png
 Engine
@@ -3597,7 +3597,7 @@ Pub
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Rex
 Cover
 Engine	godot
@@ -3613,7 +3613,7 @@ Pub	securas
 Version
 Status	runs (2021-10-29)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Rex Rocket
 Cover	Rex_Rocket_-_cover.jpg
 Engine	FNA
@@ -3629,7 +3629,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Riven
 Cover	Riven_Coverart.png
 Engine	Mohawk Engine
@@ -3645,7 +3645,7 @@ Pub	Red Orb Entertainment
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Rodent and Plank: Secret Origin
 Cover
 Engine	FNA
@@ -3661,7 +3661,7 @@ Pub	Lodder Digital Media
 Version
 Status	runs (2021-08-20)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Rogue Legacy
 Cover	Rogue_Legacy_-_cover.png
 Engine	FNA
@@ -3677,7 +3677,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Rogue State Revolution
 Cover
 Engine	godot
@@ -3693,7 +3693,7 @@ Pub	Modern Wolf
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	RollerCoaster Tycoon
 Cover	RollerCoaster_Tycoon_cover.jpg
 Engine
@@ -3709,7 +3709,7 @@ Pub	Hasbro Interactive
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	RollerCoaster Tycoon 2
 Cover	RollerCoaster_Tycoon_2_cover.jpg
 Engine
@@ -3725,7 +3725,7 @@ Pub	Infogrames
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Roma Invicta
 Cover
 Engine	godot
@@ -3741,7 +3741,7 @@ Pub	Puntigames
 Version
 Status	runs (2022-05-13)
 Added	2022-05-13
-Updated
+Updated	2022-05-13
 Game	Ruggnar
 Cover	Ruggnar_cover.png
 Engine	MonoGame
@@ -3757,7 +3757,7 @@ Pub
 Version
 Status	works with minor bugs - no gamepad support (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	RUN: The world in-between
 Cover
 Engine	godot
@@ -3773,7 +3773,7 @@ Pub	Team Run, PID Games
 Version
 Status	runs (2022-04-14)
 Added	2022-04-14
-Updated
+Updated	2022-04-14
 Game	RuneScape
 Cover
 Engine	Java
@@ -3789,7 +3789,7 @@ Pub	Jagex
 Version
 Status	major limitations - poor performance, no audio
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Rushberry Mercs
 Cover
 Engine	hashlink
@@ -3805,7 +3805,7 @@ Pub	Benjamin Soule
 Version
 Status	runs (2021-08-20)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	SEGA Mega Drive and Genesis Classics
 Cover	sega.jpg
 Engine
@@ -3821,7 +3821,7 @@ Pub
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	SJ-19 Learns To Love!
 Cover
 Engine	godot
@@ -3837,7 +3837,7 @@ Pub	Zertuk
 Version
 Status	runs (2021-09-06)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Sokobos
 Cover
 Engine	godot
@@ -3853,7 +3853,7 @@ Pub	Daisy Games
 Version
 Status	runs (2022-04-01)
 Added	2022-04-02
-Updated
+Updated	2022-04-02
 Game	SokoChess
 Cover
 Engine	godot
@@ -3885,7 +3885,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Salt and Sanctuary
 Cover	SaltAndSanctuary_header.jpg
 Engine	FNA
@@ -3901,7 +3901,7 @@ Pub
 Version
 Status	currently broken - mojoshader mismatch
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Sam & Max Hit the Road
 Cover	Sam__Max_Hit_the_Road_-_Cover.jpg
 Engine	SCUMM
@@ -3917,7 +3917,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	satryn deluxe
 Cover
 Engine	godot
@@ -3933,7 +3933,7 @@ Pub	maybell
 Version	0.9.1
 Status	runs (2021-10-31)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Session Seven
 Cover	Session_Seven_cover.jpg
 Engine
@@ -3949,7 +3949,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Settlers II
 Cover	Settlers_2_cover.jpg
 Engine
@@ -3965,7 +3965,7 @@ Pub
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Settlers
 Cover	The_Settlers_-_cover.jpg
 Engine
@@ -3981,7 +3981,7 @@ Pub
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Seven Kingdoms: Ancient Adversaries
 Cover	7kaacover.jpg
 Engine
@@ -3997,7 +3997,7 @@ Pub	Interactive Magic
 Version
 Status	needs manual setup
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Shadow Warrior Classic Redux
 Cover
 Engine	eduke32
@@ -4013,7 +4013,7 @@ Pub	3D Realms (Apogee Software)
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Shipwreck
 Cover	Shipwreck_-_cover.png
 Engine	FNA
@@ -4029,7 +4029,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Shivah
 Cover	Shivah-cover.jpg
 Engine	AGS
@@ -4045,7 +4045,7 @@ Pub	Wadjet Eye Games
 Version
 Status	runs (2021-10-13)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Signs of Life
 Cover	Signs_of_Life_-_cover.png
 Engine	XNA
@@ -4061,7 +4061,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Simona's Requiem
 Cover
 Engine	godot
@@ -4077,7 +4077,7 @@ Pub	Team Simona
 Version
 Status	runs (2022-04-29)
 Added	2022-04-29
-Updated
+Updated	2022-04-29
 Game	Skulls of the Shogun
 Cover	Skulls_of_the_Shogun_-_cover.png
 Engine	FNA
@@ -4093,7 +4093,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Slay the Spire
 Cover	Slay_the_Spire_cover.jpg
 Engine	libgdx
@@ -4109,7 +4109,7 @@ Pub
 Version
 Status	manual setup required
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Solar Rogue
 Cover
 Engine	godot
@@ -4125,7 +4125,7 @@ Pub	Ombarus Dev
 Version	1.0.1
 Status	runs (2021-12-22)
 Added	2021-12-22
-Updated
+Updated	2021-12-22
 Game	Solaroids: Prologue
 Cover	solaroids.png
 Engine	FNA
@@ -4141,7 +4141,7 @@ Pub
 Version
 Status	works with major limitations - game duration capped by DRM kicking in
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Soulcaster I & II
 Cover	Soulcaster_cover.jpg
 Engine	FNA
@@ -4157,7 +4157,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	SpaceChem
 Cover	SpaceChem_-_cover.jpg
 Engine	FontEngine
@@ -4173,7 +4173,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	SpeedRunners
 Cover	Speedrunners_cover.jpg
 Engine	XNA
@@ -4189,7 +4189,7 @@ Pub	tinyBuildGames
 Version
 Status	works with minor bugs - no gamepad support, no online multiplayer
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Star Wars: Jedi Knight - Jedi Academy
 Cover	Star_Wars_Jedi_Knight_Jedi_Academy_Cover.jpg
 Engine	id Tech 3
@@ -4205,7 +4205,7 @@ Pub	LucasArts
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Stardew Valley
 Cover	Stardew_Valley_cover.png
 Engine	MonoGame
@@ -4237,7 +4237,7 @@ Pub	Narayana Walters
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Star-Twine
 Cover
 Engine	FNA
@@ -4253,7 +4253,7 @@ Pub	SPARSE//GameDev
 Version
 Status	runs (2021-10-27)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Steel Assault
 Cover
 Engine	FNA
@@ -4269,7 +4269,7 @@ Pub	Tribute Games Inc.
 Version
 Status	runs (2021-11-10)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Strangeland
 Cover
 Engine	AGS
@@ -4285,7 +4285,7 @@ Pub	Wadjet Eye Games
 Version
 Status	runs (2021-10-28)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Strife: Veteran Edition
 Cover	Strife_Veteran_Edition_cover.jpg
 Engine	id Tech 1
@@ -4301,7 +4301,7 @@ Pub	Velocity Inc.
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Suits: A Business RPG
 Cover	Suits_A_Business_RPG_cover.jpg
 Engine
@@ -4317,7 +4317,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Sunrider: Mask of Arcadius
 Cover	Sunrider_Mask_of_Arcadius_cover.jpg
 Engine	Ren'Py 6
@@ -4333,7 +4333,7 @@ Pub	Sekai Project
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Super Amazing Wagon Adventure
 Cover	Super_Amazing_Wagon_Adventure_cover.jpg
 Engine	XNA
@@ -4349,7 +4349,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Super Bernie World
 Cover	Super_Bernie_World_cover.jpg
 Engine	FNA
@@ -4381,7 +4381,7 @@ Pub
 Version
 Status	works with minor bugs - gamepad not working (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Super Hexagon
 Cover	Super_Hexagon_cover.jpg
 Engine
@@ -4397,7 +4397,7 @@ Pub
 Version
 Status	browser needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Super Ninja Warrior Extreme
 Cover	Super_Ninja_Warrior_Extreme.png
 Engine
@@ -4413,7 +4413,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Super Rad Raygun
 Cover	Super_Rad_Raygun_cover.jpg
 Engine	FNA
@@ -4429,7 +4429,7 @@ Pub	Rooster Teeth Games
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Sword of the Stars: The Pit
 Cover	Sword_of_the_Stars_-_The_Pit_-_cover.png
 Engine	XNA
@@ -4445,7 +4445,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	System Shock
 Cover	System_Shock_cover.jpg
 Engine	System Shock engine
@@ -4461,7 +4461,7 @@ Pub	Origin Systems
 Version
 Status	works with minor bugs (2021-01-12)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Tales of Maj'Eyal
 Cover	tome.jpg
 Engine	T-Engine 4
@@ -4477,7 +4477,7 @@ Pub	Netcore
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Tanglewood
 Cover	TANGLEWOOD_cover.jpg
 Engine	megaEx
@@ -4493,7 +4493,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	TD Worlds
 Cover
 Engine	godot
@@ -4509,7 +4509,7 @@ Pub	MAKSIM VOLKAU
 Version
 Status	runs (2022-01-10)
 Added	2022-01-10
-Updated
+Updated	2022-01-10
 Game	Technobabylon
 Cover
 Engine	AGS
@@ -4525,7 +4525,7 @@ Pub	Wadjet Eye Games
 Version
 Status	runs (2021-10-13)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Terraria
 Cover	Terraria_cover.jpg
 Engine	FNA
@@ -4557,7 +4557,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Theme Hospital
 Cover	ThemeHospital.jpg
 Engine
@@ -4573,7 +4573,7 @@ Pub	Electronic Arts
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Thukothea Defender
 Cover
 Engine	godot
@@ -4589,7 +4589,7 @@ Pub	DjokaGames
 Version
 Status	runs (2021-10-15)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Timespinner
 Cover	Timespinner_cover.jpg
 Engine	FNA
@@ -4605,7 +4605,7 @@ Pub	Chucklefish Games
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Time's Up in Tiny Town
 Cover
 Engine	godot
@@ -4621,7 +4621,7 @@ Pub	6 Toad Games
 Version
 Status	runs (2021-10-15)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Titan Attacks!
 Cover	Titan_Attacks_-_cover.jpg
 Engine	lwjgl
@@ -4637,7 +4637,7 @@ Pub
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Toonstruck
 Cover	Toonstruck_-_Cover.jpg
 Engine	Toon
@@ -4653,7 +4653,7 @@ Pub	Virgin Interactive
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	TowerFall: Ascension
 Cover	TowerFall_Ascension_-_cover.jpg
 Engine	FNA
@@ -4669,7 +4669,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Tyrian 2000
 Cover	Tyrian_2000.jpg
 Engine
@@ -4685,7 +4685,7 @@ Pub	Epic MegaGames
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Ultra Hat Dimension
 Cover	Ultra_Hat_Dimension_cover.jpg
 Engine	FNA
@@ -4701,7 +4701,7 @@ Pub
 Version
 Status	works
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Ultratron
 Cover	Ultratron_-_cover.jpg
 Engine	lwjgl
@@ -4717,7 +4717,7 @@ Pub
 Version
 Status	manual setup needed
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Unavowed
 Cover
 Engine	AGS
@@ -4733,7 +4733,7 @@ Pub	Wadjet Eye Games
 Version
 Status	runs (2021-10-13)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Underlings
 Cover
 Engine	godot
@@ -4749,7 +4749,7 @@ Pub	One Man Games
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Unexplored
 Cover	Unexplored_cover.jpg
 Engine	FNA
@@ -4765,7 +4765,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Unholy Heights
 Cover	Unholy_Heights.jpg
 Engine	XNA
@@ -4781,7 +4781,7 @@ Pub	AGM PLAYISM
 Version
 Status	works (2021-09-17)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Useful Dead
 Cover	Useful_Dead.png
 Engine	XNA
@@ -4797,7 +4797,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Virtual Cottage
 Cover
 Engine	godot
@@ -4813,7 +4813,7 @@ Pub	DU&I
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	A Virus Named Tom
 Cover	A_Virus_Named_TOM_-_cover.jpg
 Engine	FNA
@@ -4845,7 +4845,7 @@ Pub	Benjamin Soule
 Version
 Status	runs
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Vomitoreum
 Cover
 Engine	gzdoom
@@ -4861,7 +4861,7 @@ Pub	Scumhead
 Version
 Status	runs (2021-10-27)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Vylan
 Cover
 Engine	godot
@@ -4877,7 +4877,7 @@ Pub	MostlyMadProductions
 Version
 Status	runs (2021-10-30)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Weapon of Choice
 Cover	Weapon_of_Choice_cover.jpg
 Engine	XNA
@@ -4893,7 +4893,7 @@ Pub
 Version
 Status	currently not working
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Wish Project
 Cover
 Engine	FNA
@@ -4909,7 +4909,7 @@ Pub	Andrew Willman
 Version
 Status	runs (2021-08-19)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	WizOrb
 Cover	Wizorb_game_cover.jpg
 Engine	FNA
@@ -4925,7 +4925,7 @@ Pub
 Version
 Status	currently not working - needs mono path fixes
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Woodland Empire
 Cover
 Engine	godot
@@ -4941,7 +4941,7 @@ Pub	Obvlong Games
 Version
 Status	runs (2021-12-22)
 Added	2021-12-22
-Updated
+Updated	2021-12-22
 Game	Word Game: Episode 0
 Cover
 Engine	godot
@@ -4957,7 +4957,7 @@ Pub	Team9
 Version
 Status	runs (2021-08-21)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Wrath: Aeon of Ruin
 Cover	Wrath_-_Aeon_of_Ruin_cover.jpg
 Engine	Darkplaces
@@ -4973,7 +4973,7 @@ Pub	3D Realms and 1C Company
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Wyv and Keep
 Cover	wyv_and_keep.png
 Engine	FNA
@@ -4989,7 +4989,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	X-Com: UFO Defense (aka UFO: Enemy Unknown)
 Cover	X-Com_UFO_Defense_Box.jpg
 Engine
@@ -5005,7 +5005,7 @@ Pub	MicroProse
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Yarntown
 Cover
 Engine	solarus
@@ -5021,7 +5021,7 @@ Pub
 Version	1.0.6
 Status	runs (2021-11-26)
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Yume Nikki
 Cover	Nikki.jpg
 Engine
@@ -5037,7 +5037,7 @@ Pub
 Version
 Status
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	The Zachtronics Solitaire Collection
 Cover
 Engine	Mono
@@ -5053,7 +5053,7 @@ Pub	Zachtronics
 Version
 Status	runs (2022-09-06)
 Added	2022-09-07
-Updated
+Updated	2022-09-07
 Game	Zak McKracken and the Alien Mindbenders
 Cover	Zak_McKracken_and_the_Alien_Mindbenders_-_Cover.jpg
 Engine	SCUMM
@@ -5069,7 +5069,7 @@ Pub
 Version
 Status	untested
 Added	1970-01-01
-Updated
+Updated	1970-01-01
 Game	Zen Bound 2
 Cover	Zen_Bound_2_cover.jpg
 Engine
@@ -5085,4 +5085,4 @@ Pub
 Version
 Status	needs browser
 Added	1970-01-01
-Updated
+Updated	1970-01-01


### PR DESCRIPTION
I have seen that, for Dice Tribes, you set the updated field to the added field by default. This PR does the same for the orther entries for consistency.